### PR TITLE
README.txt: Changed Step 1's folder to 'brackets-jspp/onux.jspp'

### DIFF
--- a/Editor Integration/Brackets/README.txt
+++ b/Editor Integration/Brackets/README.txt
@@ -4,7 +4,7 @@ This plugin provides syntax highlighting for JS++ in the Brackets editor from Ad
 
 Installation
 -
-1. Zip the 'brackets-jspp' folder.
+1. Zip the 'brackets-jspp/onux.jspp' folder.
 2. Open Adobe Brackets. In the menu, go to File -> Extension Manager.
 3. In the Extension Manager dialog box, there is a region in the bottom-left corner to drag the .zip file.
 4. Drag the zip file into the Extension Manager. Done!


### PR DESCRIPTION
I actually needed to zip the **onux.jspp** folder then drag+drop that. Zipping + dragging+dropping the 'brackets-jspp' folder resulted in a Brackets error.