### PR TITLE
[discussion] TypeScript compatibility?

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ JS++ (JSPP)
 Official website: https://www.onux.com/jspp
 
 Please visit the official website to download the JS++ compiler and stay up-to-date.
+
+TypeScript compatibility?
+-------------------------


### PR DESCRIPTION
Could JSPP perhaps adopt support for TypeScript syntax, but keep having it's own type system?

For example, imagine if we could write

```js
const n: int = 123
```

using TS syntax, but using JSPP's type system.

This would make JSPP a lot more adoptable I think, and if JSPP's type system is better than TS's, then this would be a win scenario for people looking for TypeScript alternatives while staying compatible with all the tooling already built around the language.

TypeScript has numerous issues with unsound types and management of issues that users face, so I think there is an open space for a real competitor to arise.

---

How does JSPP's type system compare to TypeScript? Could it be possible to have most, if not all, of JSPP's features with TS syntax?

---

Also seeing as how JSPP has specific number types other than just `number`, if JSPP had a TS-compatible syntax option, it could perhaps be an alternative type system for which something like [AssemblyScript, the TypeScript to WebAssembly compiler](https://assemblyscript.org/) could be built upon.

At the moment, TypeScript is pretty much the only library monopolizing static types in JavaScript, and AssemblyScript rides on that ecosystem currently.

Alternatives like [Hegel.js](https://hegel.js.org/) are also promising, but not very developed yet.

---

It would be really great to see an alternative to TypeScript rise to power ([Flow](https://flow.org/) hasn't, the IDE tooling is not very featureful, and is flaky and slow), and I think a real good strategy for that is to provide existing TypeScript users an easy path (same syntax) to a new system (JSPP).